### PR TITLE
Add Dark-Moon (GPL-3.0 autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - windows权限维持—SSP&HOOK&DSRM&SIDhistory&SkeletonKey.md
 - windows权限维持—黄金白银票据&隐藏用户&远控&RustDesk&GotoHttp.md
 
+- [Dark-Moon](https://github.com/ASCIT31/Dark-Moon)：开源（GPL-3.0）自托管自主式 AI 渗透平台，MCP 编排侦察/利用/报告智能体，覆盖 Web/API/AD/Kubernetes，本地隐私令牌化。
 ## 3.10. 渗透工具介绍与使用
 
 - ARL灯塔安装与使用.md


### PR DESCRIPTION
This PR adds Dark-Moon to the 3.10. 渗透工具介绍与使用 section. Dark-Moon is an open source (GPL-3.0) self hosted autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes, with a local Privacy Gateway so sensitive data stays on your infrastructure. It follows the existing entry format of the list. Repo: https://github.com/ASCIT31/Dark-Moon . Thanks for maintaining this resource.